### PR TITLE
index_options=offsets 설정 시  dirty offset problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin> 
     </plugins>

--- a/src/main/java/org/apache/lucene/analysis/ko/KoreanFilter.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/KoreanFilter.java
@@ -181,7 +181,9 @@ public final class KoreanFilter extends TokenFilter {
        kt.setOutputs(outputs);
     }
 
-      morphQueue.addAll(map.values());
+    final Collection<KoreanToken> sortedKoreanTokenCollection = map.values().stream()
+        .sorted(Comparator.comparingInt(KoreanToken::getOffset)).collect(Collectors.toList());
+    morphQueue.addAll(sortedKoreanTokenCollection);
   }
   
   /**

--- a/src/main/java/org/apache/lucene/analysis/ko/KoreanFilter.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/KoreanFilter.java
@@ -17,27 +17,19 @@ package org.apache.lucene.analysis.ko;
  * limitations under the License.
  */
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.ko.morph.AnalysisOutput;
-import org.apache.lucene.analysis.ko.morph.CompoundEntry;
-import org.apache.lucene.analysis.ko.morph.MorphAnalyzer;
-import org.apache.lucene.analysis.ko.morph.MorphException;
-import org.apache.lucene.analysis.ko.morph.PatternConstants;
-import org.apache.lucene.analysis.ko.morph.WordEntry;
+import org.apache.lucene.analysis.ko.morph.*;
 import org.apache.lucene.analysis.ko.utils.DictionaryUtil;
 import org.apache.lucene.analysis.ko.utils.MorphUtil;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public final class KoreanFilter extends TokenFilter {
 


### PR DESCRIPTION
안녕하세요.
먼저 arirang을 잘 사용하고 있습니다. 감사합니다.

Lucene 6.5.0(es5.4.0)으로 버전을 사용중인데 발생한 issue가 있어서 수정 후 PR드립니다.
-> index_options의 offsets 옵션 선택 시 Lucene의 DefaultIndexingChain 클래스에서 dirty offset에 대한 validation 추가로 인해 indexing이 되지 않는 케이스 수정

sorting하는데 jdk8에서 편하고 lucene도 jdk8을 완벽하게 지원한다고 해서 1.8로 소스를 수정했습니다. 혹시 다른 이유가 있어서 1.7로 사용하고 계신거면 그에 맞게 수정하여 다시 보내겠습니다.

감사합니다.